### PR TITLE
Alive Detection

### DIFF
--- a/koala/ExcelCompiler.py
+++ b/koala/ExcelCompiler.py
@@ -42,6 +42,7 @@ class ExcelCompiler(object):
         cleaned_cells, cleaned_ranged_names = sp.clean_volatile()
         self.cells = cleaned_cells
         self.named_ranges = cleaned_ranged_names
+        self.volatile_ranges = []
             
     def gen_graph(self, outputs = [], inputs = []):
         print '___### Generating Graph ###___'

--- a/koala/ExcelCompiler.py
+++ b/koala/ExcelCompiler.py
@@ -34,18 +34,14 @@ class ExcelCompiler(object):
         self.named_ranges = read_named_ranges(archive)
         self.Range = RangeFactory(self.cells)
         self.volatile_ranges = set()
-        self.volatile_arguments = None
         self.debug = debug
 
     def clean_volatile(self):
-        print '___### Cleaning volatiles ###___'
-
         sp = Spreadsheet(networkx.DiGraph(),self.cells, self.named_ranges, debug = self.debug)
 
-        cleaned_cells, cleaned_ranged_names, volatile_arguments = sp.clean_volatile()
+        cleaned_cells, cleaned_ranged_names = sp.clean_volatile()
         self.cells = cleaned_cells
         self.named_ranges = cleaned_ranged_names
-        self.volatile_arguments = volatile_arguments
             
     def gen_graph(self, outputs = [], inputs = []):
         print '___### Generating Graph ###___'
@@ -135,8 +131,8 @@ class ExcelCompiler(object):
 
 
         print "Graph construction done, %s nodes, %s edges, %s cellmap entries" % (len(G.nodes()),len(G.edges()),len(cellmap))
-        undirected = networkx.Graph(G)
-
+        
+        # undirected = networkx.Graph(G)
         # print "Number of connected components %s", str(number_connected_components(undirected))
 
-        return Spreadsheet(G, cellmap, self.named_ranges, volatile_ranges = self.volatile_ranges, outputs = outputs, inputs = inputs, volatile_arguments = self.volatile_arguments, debug = self.debug)
+        return Spreadsheet(G, cellmap, self.named_ranges, volatile_ranges = self.volatile_ranges, outputs = outputs, inputs = inputs, debug = self.debug)

--- a/koala/ast/__init__.py
+++ b/koala/ast/__init__.py
@@ -441,7 +441,6 @@ def graph_from_seeds(seeds, cell_source):
             G.add_node(c)
             cellmap[c.address()] = c
     # when called from ExcelCompiler instance, construct cellmap and graph from seeds 
-    # elif isinstance(cell_source, ExcelCompiler):
     else: # ~ cell_source is a ExcelCompiler
         cellmap = dict([(x.address(),x) for x in seeds])
         cells = cell_source.cells
@@ -542,7 +541,7 @@ def graph_from_seeds(seeds, cell_source):
                 # add an edge from the range to the parent
                 G.add_node(virtual_cell)
                 # Cell(A1:A10) -> c1 or Cell(ExampleName) -> c1
-                G.add_edge(virtual_cell, cellmap[c1.address()])
+                G.add_edge(virtual_cell, c1)
                 # cells in the range should point to the range as their parent
                 target = virtual_cell 
                 origins = []
@@ -564,14 +563,19 @@ def graph_from_seeds(seeds, cell_source):
                 if reference in cells:
                     if dep_name in names:
                         virtual_cell = Cell(dep_name, None, value = cells[reference].value, formula = reference, is_range = False, is_named_range = True )
+                        
+                        G.add_node(virtual_cell)
+                        G.add_edge(cells[reference], virtual_cell)
+
                         origins = [virtual_cell]
                     else:
                         origins = [cells[reference]] 
                 else:
+                    # print 'DEP NAME not in cells'
                     virtual_cell = Cell(dep_name, None, value = None, formula = None, is_range = False, is_named_range = True )
                     origins = [virtual_cell]
 
-                target = cellmap[c1.address()]
+                target = c1
 
 
             # process each cell                    
@@ -597,7 +601,7 @@ def graph_from_seeds(seeds, cell_source):
                 # add an edge from the cell to the parent (range or cell)
                 if(target != []):
                     # print "Adding edge %s --> %s" % (c2.address(), target.address())
-                    G.add_edge(cellmap[c2.address()],target)
+                    G.add_edge(c2,target)
         
         c1.compile() # cell compilation is done here because volatile ranges might update python_expressions 
 

--- a/koala/serializer.py
+++ b/koala/serializer.py
@@ -87,9 +87,6 @@ def dump(self, fname, marshal = False):
     if self.inputs is not None:
         outfile.write("inputs" + "\n")
         outfile.write(SEP.join(self.inputs) + "\n")
-    if self.volatile_arguments is not None:
-        outfile.write("vol_args" + "\n")
-        outfile.write(SEP.join(self.volatile_arguments) + "\n")
     outfile.write("named_ranges" + "\n")
     for k in self.named_ranges:
         outfile.write(k + SEP + self.named_ranges[k] + "\n")
@@ -157,9 +154,6 @@ def load(fname):
         elif line == "named_ranges":
             mode = "named_ranges"
             continue
-        elif line == "vol_args":
-            mode = "vol_args"
-            continue
 
         if mode == "node0":
             [address, formula, python_expression, is_range, is_named_range, is_volatile, should_eval] = line.split(SEP)
@@ -204,14 +198,12 @@ def load(fname):
         elif mode == "named_ranges":
             k,v = line.split(SEP)
             named_ranges[k] = v
-        elif mode == "vol_args":
-            volatile_arguments = line.split(SEP)
 
     G = DiGraph(data = edges)
 
     print "Graph loading done, %s nodes, %s edges, %s cellmap entries" % (len(G.nodes()),len(G.edges()),len(cellmap))
 
-    return (G, cellmap, named_ranges, volatile_ranges, outputs, inputs, volatile_arguments)
+    return (G, cellmap, named_ranges, volatile_ranges, outputs, inputs)
 
 ########### based on json #################
 def dump_json(self, fname):

--- a/koala/serializer.py
+++ b/koala/serializer.py
@@ -87,9 +87,13 @@ def dump(self, fname, marshal = False):
     if self.inputs is not None:
         outfile.write("inputs" + "\n")
         outfile.write(SEP.join(self.inputs) + "\n")
+    if self.volatile_arguments is not None:
+        outfile.write("vol_args" + "\n")
+        outfile.write(SEP.join(self.volatile_arguments) + "\n")
     outfile.write("named_ranges" + "\n")
     for k in self.named_ranges:
         outfile.write(k + SEP + self.named_ranges[k] + "\n")
+    
 
     outfile.close()
 
@@ -153,8 +157,8 @@ def load(fname):
         elif line == "named_ranges":
             mode = "named_ranges"
             continue
-        elif line == "volatile_ranges":
-            mode = "volatile_ranges"
+        elif line == "vol_args":
+            mode = "vol_args"
             continue
 
         if mode == "node0":
@@ -200,12 +204,14 @@ def load(fname):
         elif mode == "named_ranges":
             k,v = line.split(SEP)
             named_ranges[k] = v
+        elif mode == "vol_args":
+            volatile_arguments = line.split(SEP)
 
     G = DiGraph(data = edges)
 
     print "Graph loading done, %s nodes, %s edges, %s cellmap entries" % (len(G.nodes()),len(G.edges()),len(cellmap))
 
-    return (G, cellmap, named_ranges, volatile_ranges, outputs, inputs)
+    return (G, cellmap, named_ranges, volatile_ranges, outputs, inputs, volatile_arguments)
 
 ########### based on json #################
 def dump_json(self, fname):


### PR DESCRIPTION
This PR enables the capability to detect alive volatiles inside a input-output calculation chain (fixes #77)

This is done in 2 steps:
- Get all arguments and sub arguments of all volatiles functions (for now `INDEX` and `OFFSET`), starting from all outputs. Call these `volatile_arguments`.
- Climb down the graph from all inputs to check if each cell on the way is not part of the `volatile_arguments`

You can use this with `Spreadsheet.detect_alive()`, which will trigger the 2 steps by itself.
This is very useful to ensure you can `clean_volatiles()` and generate a subsequent subgraph.
